### PR TITLE
fix camera release bug

### DIFF
--- a/Android/app/src/main/java/com/alibaba/android/mnnkit/demo/view/CameraView.java
+++ b/Android/app/src/main/java/com/alibaba/android/mnnkit/demo/view/CameraView.java
@@ -22,7 +22,7 @@ public class CameraView extends SurfaceView implements SurfaceHolder.Callback, C
 
     private static final int MINIMUM_PREVIEW_SIZE = 320;
 
-    static private Camera mCamera;
+    private static Camera mCamera;
     private static int mCameraId = Camera.CameraInfo.CAMERA_FACING_FRONT;
     private Camera.Parameters mParams;
     private Camera.Size mPreviewSize;

--- a/Android/app/src/main/java/com/alibaba/android/mnnkit/demo/view/CameraView.java
+++ b/Android/app/src/main/java/com/alibaba/android/mnnkit/demo/view/CameraView.java
@@ -108,7 +108,7 @@ public class CameraView extends SurfaceView implements SurfaceHolder.Callback, C
         mCamera.startPreview();
     }
 
-    static private synchronized void releaseCamera() {
+    private static synchronized void releaseCamera() {
         if (mCamera != null) {
             try {
                 mCamera.setPreviewCallback(null);

--- a/Android/app/src/main/java/com/alibaba/android/mnnkit/demo/view/CameraView.java
+++ b/Android/app/src/main/java/com/alibaba/android/mnnkit/demo/view/CameraView.java
@@ -22,7 +22,7 @@ public class CameraView extends SurfaceView implements SurfaceHolder.Callback, C
 
     private static final int MINIMUM_PREVIEW_SIZE = 320;
 
-    private Camera mCamera;
+    static private Camera mCamera;
     private static int mCameraId = Camera.CameraInfo.CAMERA_FACING_FRONT;
     private Camera.Parameters mParams;
     private Camera.Size mPreviewSize;
@@ -38,6 +38,7 @@ public class CameraView extends SurfaceView implements SurfaceHolder.Callback, C
     private int mDeviecAutoRotateAngle;
 
     public static void resetCameraId() {
+        releaseCamera();
         mCameraId = Camera.CameraInfo.CAMERA_FACING_FRONT;
     }
 
@@ -107,7 +108,7 @@ public class CameraView extends SurfaceView implements SurfaceHolder.Callback, C
         mCamera.startPreview();
     }
 
-    private synchronized void releaseCamera() {
+    static private synchronized void releaseCamera() {
         if (mCamera != null) {
             try {
                 mCamera.setPreviewCallback(null);


### PR DESCRIPTION
修复了一个相机释放的bug。

如何复现这个bug? 运行目前master分支的代码(android), 在手机上安装好MNNKi Demo后, 点击`人脸检测`, 这时默认会打开前置摄像头, 然后点击摄像头切换, 使摄像头变为后置, 这时看起来都还很正常, 然后点击左上角的返回按钮, 返回到最开始的界面, 然后再点击`人脸检测`就会发现屏幕是白屏的。

我看了整个代码, 出现白屏的原因其实应该会导致整个app crash掉, 但是在程序里, 用了try-catch异常, 所以只是白屏.

出现白屏的原因通过阅读完整个代码后, 也很容易发现, 就是我们在返回主界面时, 没有释放掉camera的资源, 这里可以类比c++的RAII技法, 一个对象在结束后, 这个对象所管理的资源应该被正确的释放.